### PR TITLE
Update sidebar layout with pots and plants

### DIFF
--- a/Plantify new/plantify/app.py
+++ b/Plantify new/plantify/app.py
@@ -23,13 +23,19 @@ app.register_blueprint(users_blueprint, url_prefix='/api')
 app.register_blueprint(plants_blueprint, url_prefix='/api')
 app.register_blueprint(authorization_blueprint, url_prefix='/api')
 
-# Dummy Items für Sidebar
-ITEMS = [
+# Dummy-Daten für Sidebar
+POTS = [
+    {"name": "Keramik"},
+    {"name": "Terrakotta"},
+    {"name": "Kunststoff"}
+]
+
+PLANTS = [
     {"name": "Tomate"},
     {"name": "Orchidee"},
     {"name": "Monstera"},
     {"name": "Strelitzie"},
-    {"name": "Orchidee"},
+    {"name": "Orchidee 2"},
 ]
 
 # --- Login-Decorator für geschützte Seiten ---
@@ -66,7 +72,7 @@ def logout():
 # API für Sidebar
 @app.route('/api/items')
 def api_items():
-    return jsonify(ITEMS)
+    return jsonify({"pots": POTS, "plants": PLANTS})
 
 # Item-Detailseite (Platzhalter)
 @app.route('/pflanze/<name>')

--- a/Plantify new/plantify/static/sidebar.js
+++ b/Plantify new/plantify/static/sidebar.js
@@ -2,29 +2,38 @@ document.addEventListener('DOMContentLoaded', function () {
     fetch('/api/items')
         .then(response => response.json())
         .then(data => {
-            // Sortierung wie auf Screenshot 2
+            const potList = document.getElementById('sidebar-pots');
+            const plantList = document.getElementById('sidebar-plants');
+            potList.innerHTML = '';
+            plantList.innerHTML = '';
+
+            const pots = data.pots || [];
+            pots.forEach(pot => {
+                const li = document.createElement('li');
+                const link = document.createElement('a');
+                link.href = '#';
+                link.innerHTML = `🏺 <span class="sidebar-text">${pot.name}</span>`;
+                li.appendChild(link);
+                potList.appendChild(li);
+            });
+
+            const plants = data.plants || [];
             const sortOrder = [
                 "monstera", "strelitzie", "orchidee", "tomate", "orchidee 2", "monstera 2"
             ];
-            data.sort((a, b) => {
+            plants.sort((a, b) => {
                 const aIdx = sortOrder.indexOf(a.name.toLowerCase());
                 const bIdx = sortOrder.indexOf(b.name.toLowerCase());
                 return (aIdx === -1 ? 99 : aIdx) - (bIdx === -1 ? 99 : bIdx);
             });
 
-            const list = document.getElementById('sidebar-list');
-            list.innerHTML = '';
-
-            data.forEach(item => {
+            plants.forEach(item => {
                 const li = document.createElement('li');
                 const link = document.createElement('a');
                 link.href = `/pflanze/${item.name.toLowerCase().replace(/\s+/g, '-')}`;
-
-                // Einheitliches, neutrales Icon (🪴)
                 link.innerHTML = `🪴 <span class="sidebar-text">${item.name}</span>`;
-
                 li.appendChild(link);
-                list.appendChild(li);
+                plantList.appendChild(li);
             });
         })
         .catch(error => {

--- a/Plantify new/plantify/static/style.css
+++ b/Plantify new/plantify/static/style.css
@@ -176,6 +176,34 @@ body.sidebar-collapsed .sidebar ul li a {
     color: #388e3c;
 }
 
+.sidebar-bottom ul {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+}
+
+.sidebar-bottom ul li {
+    margin-bottom: 14px;
+}
+
+.sidebar-bottom ul li a {
+    display: flex;
+    align-items: center;
+    gap: 9px;
+    font-size: 19px;
+    padding: 6px 12px;
+    border-radius: 6px;
+    font-family: inherit;
+    color: #262626;
+    text-decoration: none;
+    transition: background 0.2s, color 0.2s;
+}
+
+.sidebar-bottom ul li a:hover {
+    background: #e7e7e7;
+    color: #388e3c;
+}
+
 /* Inhaltsbereich */
 .content {
     height: calc(100vh - 60px);
@@ -294,12 +322,14 @@ body.dark-mode .card h3 {
 }
 body.dark-mode .sidebar h2,
 body.dark-mode .sidebar ul li a,
-body.dark-mode .sidebar-bottom a {
+body.dark-mode .sidebar-bottom a,
+body.dark-mode .sidebar-bottom ul li a {
     color: #f0f0f0;
 }
 body.dark-mode .sidebar ul li a:hover,
 body.dark-mode .sidebar ul li a.active,
-body.dark-mode .sidebar-bottom a:hover {
+body.dark-mode .sidebar-bottom a:hover,
+body.dark-mode .sidebar-bottom ul li a:hover {
     background-color: #66bb6a;
     color: #ffffff;
 }

--- a/Plantify new/plantify/templates/base.html
+++ b/Plantify new/plantify/templates/base.html
@@ -30,7 +30,10 @@
     </div>
     <aside class="sidebar">
       <div class="sidebar-scrollable">
-        <ul id="sidebar-list"></ul>
+        <ul id="sidebar-pots"></ul>
+        <div class="sidebar-bottom">
+          <ul id="sidebar-plants"></ul>
+        </div>
       </div>
     </aside>
     <main class="content">


### PR DESCRIPTION
## Summary
- change sidebar structure to show pot types and plant list separately
- style new sidebar section and update dark mode rules
- fetch both pots and plants from API
- update `/api/items` to return lists of pots and plants

## Testing
- `python3 -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_684fd8301848832f8468acff079a0b38