### PR TITLE
Fix pot links

### DIFF
--- a/Plantify new/plantify/static/sidebar.js
+++ b/Plantify new/plantify/static/sidebar.js
@@ -12,7 +12,7 @@ document.addEventListener('DOMContentLoaded', function () {
             pots.forEach(pot => {
                 const li = document.createElement('li');
                 const link = document.createElement('a');
-                link.href = '#';
+                link.href = '/';
                 link.innerHTML = `🏺 <span class="sidebar-text">${pot.name}</span>`;
                 li.appendChild(link);
                 potList.appendChild(li);


### PR DESCRIPTION
## Summary
- show pots first in sidebar again
- link pot entries to the dashboard

## Testing
- `python3 -m py_compile 'Plantify new/plantify/app.py' 'Plantify new/plantify/auth.py' 'Plantify new/plantify/main.py'`

------
https://chatgpt.com/codex/tasks/task_e_684ff78929dc832f98075da7173a2245