### PR TITLE
Add dashboard and plant editing features

### DIFF
--- a/Plantify new/plantify/static/sidebar.js
+++ b/Plantify new/plantify/static/sidebar.js
@@ -7,24 +7,24 @@ document.addEventListener('DOMContentLoaded', function () {
             potList.innerHTML = '';
             plantList.innerHTML = '';
 
-            const pots = data.plants || [];
-            // Reihenfolge wie geliefert anzeigen
-            pots.forEach(pot => {
+            const slugify = str => str.toLowerCase().replace(/\s+/g, '-');
+
+            const rooms = data.rooms || [];
+            rooms.forEach(room => {
                 const li = document.createElement('li');
                 const link = document.createElement('a');
-                link.href = `/pflanze/${pot.name.toLowerCase().replace(/\s+/g, '-')}`;
-                link.innerHTML = `🪴 <span class="sidebar-text">${pot.name}</span>`;
+                link.href = `/dashboard/${slugify(room.name)}`;
+                link.innerHTML = `🏠 <span class="sidebar-text">${room.name}</span>`;
                 li.appendChild(link);
                 potList.appendChild(li);
             });
 
-            const plants = data.pots || [];
-
-            plants.forEach(item => {
+            const plants = data.plants || [];
+            plants.forEach(plant => {
                 const li = document.createElement('li');
                 const link = document.createElement('a');
-                link.href = '#';
-                link.innerHTML = `🏺 <span class="sidebar-text">${item.name}</span>`;
+                link.href = `/pflanze/${slugify(plant.name)}`;
+                link.innerHTML = `🪴 <span class="sidebar-text">${plant.name}</span>`;
                 li.appendChild(link);
                 plantList.appendChild(li);
             });

--- a/Plantify new/plantify/templates/dashboard.html
+++ b/Plantify new/plantify/templates/dashboard.html
@@ -1,0 +1,15 @@
+{% extends 'base.html' %}
+
+{% block title %}Dashboard - {{ room }}{% endblock %}
+{% block page_title %}Dashboard - {{ room }}{% endblock %}
+
+{% block content %}
+<h2>Pflanzen im {{ room }}</h2>
+<ul>
+{% for plant in plants %}
+  <li>{{ plant.name }}</li>
+{% else %}
+  <li>Keine Pflanzen zugeordnet.</li>
+{% endfor %}
+</ul>
+{% endblock %}

--- a/Plantify new/plantify/templates/plant.html
+++ b/Plantify new/plantify/templates/plant.html
@@ -20,7 +20,16 @@
     </div>
     <div class="card" id="facts-box">
         <h3>Pflanzen Fakten</h3>
-        <p id="plant-facts">Wird geladen...</p>
+        <textarea id="facts-textarea" class="pflege-edit" rows="3" placeholder="Fakten hier eingeben...">{{ plant.facts }}</textarea>
+        <div style="margin-top:10px;">
+            <label for="room-select">Zimmer:</label>
+            <select id="room-select" class="pflege-edit" style="height:auto;">
+                {% for room in rooms %}
+                <option value="{{ room.name }}" {% if room.name == plant.room %}selected{% endif %}>{{ room.name }}</option>
+                {% endfor %}
+            </select>
+        </div>
+        <button id="save-facts-btn" class="pflege-edit" style="margin-top:10px;">Speichern</button>
     </div>
     <div class="card">
         <h3>Sonnenstunden</h3>
@@ -54,6 +63,20 @@ document.addEventListener('DOMContentLoaded', function () {
       this.style.height = Math.max(this.scrollHeight, 40) + 'px';
     });
     textarea.dispatchEvent(new Event('input'));
+  }
+
+  const saveBtn = document.getElementById('save-facts-btn');
+  if (saveBtn) {
+    saveBtn.addEventListener('click', async function () {
+      const facts = document.getElementById('facts-textarea').value;
+      const room = document.getElementById('room-select').value;
+      await fetch('/api/plants/{{ plant.id }}', {
+        method: 'POST',
+        headers: {'Content-Type': 'application/json'},
+        body: JSON.stringify({facts: facts, room: room})
+      });
+      alert('Gespeichert');
+    });
   }
 });
 </script>


### PR DESCRIPTION
## Summary
- manage rooms and plants in `app.py`
- provide API routes for plant updates
- show rooms and plants in the sidebar
- add dashboard page for rooms
- allow editing plant facts and room assignment

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python app.py` *(fails: ModuleNotFoundError: No module named 'bcrypt')*

------
https://chatgpt.com/codex/tasks/task_e_6852c053d154832f9ae887fd04ad4d71