### PR TITLE
Rename Pflegehinweise section

### DIFF
--- a/Plantify new/plantify/templates/dashboard.html
+++ b/Plantify new/plantify/templates/dashboard.html
@@ -6,7 +6,7 @@
 {% block content %}
 <div class="dashboard">
     <div class="card full-width-card" id="care-guidelines">
-        <h3>Allgemeine Pflegehinweise</h3>
+        <h3>Schnellübersicht</h3>
         <table class="care-table">
             <thead>
                 <tr>

--- a/Plantify new/plantify/templates/plant.html
+++ b/Plantify new/plantify/templates/plant.html
@@ -6,7 +6,7 @@
 {% block content %}
 <div class="dashboard">
     <div class="card full-width-card" id="extra-facts">
-        <h3>Allgemeine Pflegehinweise</h3>
+        <h3>Schnellübersicht</h3>
         <div>
             <label for="target-temperature">Temperatur (°C)</label>
             <input type="number" id="target-temperature" class="pflege-edit"


### PR DESCRIPTION
## Summary
- rename "Allgemeine Pflegehinweise" section to "Schnellübersicht" on the dashboard page
- rename the same heading on the plant page

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6852d85ace8c832fa79b4fde700fee9a