### PR TITLE
Fix facts card height in dashboard

### DIFF
--- a/Plantify new/plantify/static/style.css
+++ b/Plantify new/plantify/static/style.css
@@ -277,7 +277,7 @@ canvas {
 
 .facts-card {
     grid-column: 3;
-    grid-row: span 2;
+    grid-row: 2;
 }
 
 /* Toggle-Switch (Light/Dark Mode) */


### PR DESCRIPTION
## Summary
- set `grid-row` to `2` for the Pflanzenfakten card so it matches the height of the charts

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685a8b93cad0832f85bb20609c0fbd61