### PR TITLE
Allow duplicate plant names in multiple rooms

### DIFF
--- a/Plantify new/plantify/static/sidebar.js
+++ b/Plantify new/plantify/static/sidebar.js
@@ -23,7 +23,9 @@ document.addEventListener('DOMContentLoaded', function () {
             plants.forEach(plant => {
                 const li = document.createElement('li');
                 const link = document.createElement('a');
-                link.href = `/pflanze/${slugify(plant.name)}`;
+                // Include the plant id in the slug so plants with the same name
+                // can be displayed in different rooms.
+                link.href = `/pflanze/${slugify(plant.name)}-${plant.id}`;
                 link.innerHTML = `🪴 <span class="sidebar-text">${plant.name}</span>`;
                 li.appendChild(link);
                 plantList.appendChild(li);


### PR DESCRIPTION
## Summary
- support plants with identical names by adding `plant_slug`
- resolve plant by ID from slug
- update sidebar links to include plant ID

## Testing
- `pytest -q`
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_685a8c2eecd0832f9ddcccef8ff17ee5