### PR TITLE
Fix plant facts layout

### DIFF
--- a/Plantify new/plantify/static/style.css
+++ b/Plantify new/plantify/static/style.css
@@ -280,6 +280,11 @@ canvas {
     grid-row: 2;
 }
 
+/* Ensure plant facts content starts at the top */
+#facts-box {
+    justify-content: flex-start;
+}
+
 /* Toggle-Switch (Light/Dark Mode) */
 .switch {
     position: relative;


### PR DESCRIPTION
## Summary
- adjust dashboard facts box so text starts at the top

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_685a8dc164c8832f97e57a9ed79795ce