### PR TITLE
Enable updating names for plants and rooms

### DIFF
--- a/Plantify new/plantify/templates/dashboard.html
+++ b/Plantify new/plantify/templates/dashboard.html
@@ -5,6 +5,11 @@
 
 {% block content %}
 <div class="dashboard">
+    <div class="card full-width-card" id="room-edit-box">
+        <label for="room-name">Zimmername:</label>
+        <input type="text" id="room-name" class="pflege-edit" value="{{ room }}">
+        <button id="save-room-btn" class="pflege-edit">Speichern</button>
+    </div>
     <div class="card full-width-card" id="care-guidelines">
         <h3>Schnellübersicht</h3>
         <table class="care-table">
@@ -64,4 +69,26 @@
 <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
 <script src="{{ url_for('static', filename='plant.js') }}"></script>
 <script src="{{ url_for('static', filename='dashboard.js') }}"></script>
+<script>
+document.addEventListener('DOMContentLoaded', function () {
+    const saveRoomBtn = document.getElementById('save-room-btn');
+    if (saveRoomBtn) {
+        saveRoomBtn.addEventListener('click', async function () {
+            const name = document.getElementById('room-name').value;
+            const slug = '{{ room_slug }}';
+            const newSlug = name.toLowerCase().replace(/\s+/g, '-');
+            await fetch('/api/rooms/' + slug, {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ name })
+            });
+            if (newSlug !== slug) {
+                window.location.href = '/dashboard/' + newSlug;
+            } else {
+                alert('Zimmername gespeichert');
+            }
+        });
+    }
+});
+</script>
 {% endblock %}

--- a/Plantify new/plantify/templates/plant.html
+++ b/Plantify new/plantify/templates/plant.html
@@ -30,6 +30,10 @@
     </div>
     <div class="card" id="facts-box">
         <h3>Pflanzen Fakten</h3>
+        <div>
+            <label for="plant-name">Name:</label>
+            <input type="text" id="plant-name" class="pflege-edit" value="{{ plant.name }}">
+        </div>
         <textarea id="facts-textarea" class="pflege-edit" rows="3" placeholder="Fakten hier eingeben...">{{ plant.facts }}</textarea>
         <div style="margin-top:10px;">
             <label for="room-select">Zimmer:</label>
@@ -55,6 +59,7 @@ document.addEventListener('DOMContentLoaded', function () {
   if (saveBtn) {
     saveBtn.addEventListener('click', async function () {
       const facts = document.getElementById('facts-textarea').value;
+      const name = document.getElementById('plant-name').value;
       const roomSelect = document.getElementById('room-select');
       const room = roomSelect.value || null;
       const targetTemperature = document.getElementById('target-temperature').value;
@@ -65,13 +70,20 @@ document.addEventListener('DOMContentLoaded', function () {
         headers: {'Content-Type': 'application/json'},
         body: JSON.stringify({
           facts: facts,
+          name: name,
           room: room,
           target_temperature: targetTemperature,
           target_air_humidity: targetAirHumidity,
           target_ground_humidity: targetGroundHumidity
         })
       });
-      alert('Gespeichert');
+      const newSlug = name.toLowerCase().replace(/\s+/g, '-') + '-{{ plant.id }}';
+      const currentSlug = window.location.pathname.split('/').pop();
+      if (newSlug !== currentSlug) {
+        window.location.href = '/pflanze/' + newSlug;
+      } else {
+        alert('Gespeichert');
+      }
     });
   }
 });


### PR DESCRIPTION
## Summary
- allow updating plant name via `/api/plants/<id>`
- add `/api/rooms/<slug>` endpoint to rename a room
- update templates to include inputs for plant and room names
- update JS to redirect when a name change alters the slug

## Testing
- `python3 -m py_compile 'Plantify new/plantify/app.py'`
- `python3 -m py_compile 'Plantify new/plantify/api_project/smartplant_api/plants.py'`
- `python3 -m py_compile 'Plantify new/plantify/api_project/smartplant_api/users.py'`
- `python3 -m py_compile 'Plantify new/plantify/api_project/smartplant_api/views.py'`


------
https://chatgpt.com/codex/tasks/task_e_685a98aa04dc832f9f16790bc6e28469