### PR TITLE
Add rooms management page

### DIFF
--- a/Plantify new/plantify/app.py
+++ b/Plantify new/plantify/app.py
@@ -180,6 +180,13 @@ def dashboard(slug):
     plants = [p for p in PLANTS if p.get('room') == room['name']]
     return render_template('dashboard.html', room=room['name'], room_slug=slug, plants=plants)
 
+# Seite zum Umbenennen der Zimmer
+@app.route('/rooms')
+@login_required
+def rooms_page():
+    room_entries = [{'name': r['name'], 'slug': slugify(r['name'])} for r in ROOMS]
+    return render_template('rooms.html', rooms=room_entries)
+
 # Plantendetail und Bearbeitung
 @app.route('/pflanze/<slug>')
 @login_required

--- a/Plantify new/plantify/templates/base.html
+++ b/Plantify new/plantify/templates/base.html
@@ -22,6 +22,7 @@
             </button>
             <div class="dropdown-menu" id="profile-dropdown-menu">
               <a href="/settings">Einstellungen</a>
+              <a href="/rooms">Zimmer verwalten</a>
               <a href="/logout">Abmelden</a>
             </div>
           </div>

--- a/Plantify new/plantify/templates/dashboard.html
+++ b/Plantify new/plantify/templates/dashboard.html
@@ -5,11 +5,6 @@
 
 {% block content %}
 <div class="dashboard">
-    <div class="card full-width-card" id="room-edit-box">
-        <label for="room-name">Zimmername:</label>
-        <input type="text" id="room-name" class="pflege-edit" value="{{ room }}">
-        <button id="save-room-btn" class="pflege-edit">Speichern</button>
-    </div>
     <div class="card full-width-card" id="care-guidelines">
         <h3>Schnellübersicht</h3>
         <table class="care-table">
@@ -69,26 +64,4 @@
 <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
 <script src="{{ url_for('static', filename='plant.js') }}"></script>
 <script src="{{ url_for('static', filename='dashboard.js') }}"></script>
-<script>
-document.addEventListener('DOMContentLoaded', function () {
-    const saveRoomBtn = document.getElementById('save-room-btn');
-    if (saveRoomBtn) {
-        saveRoomBtn.addEventListener('click', async function () {
-            const name = document.getElementById('room-name').value;
-            const slug = '{{ room_slug }}';
-            const newSlug = name.toLowerCase().replace(/\s+/g, '-');
-            await fetch('/api/rooms/' + slug, {
-                method: 'POST',
-                headers: { 'Content-Type': 'application/json' },
-                body: JSON.stringify({ name })
-            });
-            if (newSlug !== slug) {
-                window.location.href = '/dashboard/' + newSlug;
-            } else {
-                alert('Zimmername gespeichert');
-            }
-        });
-    }
-});
-</script>
 {% endblock %}

--- a/Plantify new/plantify/templates/rooms.html
+++ b/Plantify new/plantify/templates/rooms.html
@@ -1,0 +1,39 @@
+{% extends 'base.html' %}
+
+{% block title %}Zimmer verwalten{% endblock %}
+{% block page_title %}Zimmer verwalten{% endblock %}
+
+{% block content %}
+<div class="dashboard">
+  <div class="card full-width-card">
+    <h3>Zimmer umbenennen</h3>
+    <ul id="room-list" style="list-style:none;padding:0;">
+      {% for room in rooms %}
+      <li style="display:flex;gap:10px;margin-bottom:10px;">
+        <input type="text" class="pflege-edit room-input" value="{{ room.name }}" data-slug="{{ room.slug }}">
+        <button class="pflege-edit save-room-btn" style="max-width:150px;">Speichern</button>
+      </li>
+      {% endfor %}
+    </ul>
+  </div>
+</div>
+<script>
+  document.addEventListener('DOMContentLoaded', function(){
+    document.querySelectorAll('.save-room-btn').forEach(function(btn){
+      btn.addEventListener('click', async function(){
+        const input = this.previousElementSibling;
+        const slug = input.dataset.slug;
+        const name = input.value;
+        const newSlug = name.toLowerCase().replace(/\s+/g,'-');
+        await fetch('/api/rooms/'+slug, {
+          method:'POST',
+          headers:{'Content-Type':'application/json'},
+          body: JSON.stringify({name:name})
+        });
+        input.dataset.slug = newSlug;
+        alert('Zimmername gespeichert');
+      });
+    });
+  });
+</script>
+{% endblock %}


### PR DESCRIPTION
## Summary
- add "Zimmer verwalten" entry to profile dropdown
- create dedicated rooms management page
- remove room rename box from dashboard

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685a9f67988c832f95ff581bb61f3762