### PR TITLE
Add ability to create rooms from management page

### DIFF
--- a/Plantify new/plantify/app.py
+++ b/Plantify new/plantify/app.py
@@ -133,6 +133,19 @@ def logout():
 def api_items():
     return jsonify({"rooms": ROOMS, "plants": PLANTS})
 
+# Endpoint to create a new room
+@app.route('/api/rooms', methods=['POST'])
+def create_room():
+    data = request.get_json() or {}
+    name = data.get('name')
+    if not name:
+        return jsonify({"error": "missing name"}), 400
+    if any(r['name'].lower() == name.lower() for r in ROOMS):
+        return jsonify({"error": "exists"}), 400
+    room = {"name": name}
+    ROOMS.append(room)
+    return jsonify(room), 201
+
 # Endpoint to update room names
 @app.route('/api/rooms/<slug>', methods=['POST'])
 def update_room(slug):

--- a/Plantify new/plantify/templates/rooms.html
+++ b/Plantify new/plantify/templates/rooms.html
@@ -16,15 +16,24 @@
       {% endfor %}
     </ul>
   </div>
+  <div class="card full-width-card" style="margin-top:20px;">
+    <h3>Neues Zimmer hinzufügen</h3>
+    <div style="display:flex;gap:10px;">
+      <input type="text" id="new-room-input" class="pflege-edit" placeholder="Zimmername">
+      <button id="add-room-btn" class="pflege-edit" style="max-width:150px;">Hinzufügen</button>
+    </div>
+  </div>
 </div>
 <script>
   document.addEventListener('DOMContentLoaded', function(){
-    document.querySelectorAll('.save-room-btn').forEach(function(btn){
+    const slugify = str => str.toLowerCase().replace(/\s+/g,'-');
+
+    function setupSave(btn){
       btn.addEventListener('click', async function(){
         const input = this.previousElementSibling;
         const slug = input.dataset.slug;
         const name = input.value;
-        const newSlug = name.toLowerCase().replace(/\s+/g,'-');
+        const newSlug = slugify(name);
         await fetch('/api/rooms/'+slug, {
           method:'POST',
           headers:{'Content-Type':'application/json'},
@@ -33,7 +42,47 @@
         input.dataset.slug = newSlug;
         alert('Zimmername gespeichert');
       });
-    });
+    }
+
+    document.querySelectorAll('.save-room-btn').forEach(setupSave);
+
+    const addBtn = document.getElementById('add-room-btn');
+    if(addBtn){
+      addBtn.addEventListener('click', async function(){
+        const input = document.getElementById('new-room-input');
+        const name = input.value.trim();
+        if(!name) return;
+        const res = await fetch('/api/rooms', {
+          method:'POST',
+          headers:{'Content-Type':'application/json'},
+          body: JSON.stringify({name:name})
+        });
+        if(res.ok){
+          const slug = slugify(name);
+          const li = document.createElement('li');
+          li.style.display='flex';
+          li.style.gap='10px';
+          li.style.marginBottom='10px';
+          const newInput = document.createElement('input');
+          newInput.type='text';
+          newInput.className='pflege-edit room-input';
+          newInput.value=name;
+          newInput.dataset.slug=slug;
+          const newBtn = document.createElement('button');
+          newBtn.className='pflege-edit save-room-btn';
+          newBtn.style.maxWidth='150px';
+          newBtn.textContent='Speichern';
+          li.appendChild(newInput);
+          li.appendChild(newBtn);
+          document.getElementById('room-list').appendChild(li);
+          setupSave(newBtn);
+          input.value='';
+          alert('Zimmer hinzugefügt');
+        } else {
+          alert('Fehler beim Hinzufügen');
+        }
+      });
+    }
   });
 </script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- allow creating rooms through new `/api/rooms` endpoint
- extend *Zimmer verwalten* page with a form to add rooms via JavaScript

## Testing
- `python -m py_compile "Plantify new/plantify/app.py"`
- `find 'Plantify new/plantify' -name '*.py' -print0 | xargs -0 python -m py_compile`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685aaa810cb0832fafc8de9c2f1338be