### PR TITLE
Add temperature chart in plant detail

### DIFF
--- a/Plantify new/plantify/static/temperature_chart.js
+++ b/Plantify new/plantify/static/temperature_chart.js
@@ -1,0 +1,27 @@
+const API_BASE = '/api';
+
+document.addEventListener('DOMContentLoaded', async () => {
+    const potId = new URLSearchParams(window.location.search).get('pot_id') || '1';
+    const ctx = document.getElementById('chart-temp');
+    if (!ctx) return;
+
+    const chart = new Chart(ctx, {
+        type: 'line',
+        data: { labels: [], datasets: [{ label: 'Temperatur (°C)', data: [], borderColor: 'rgb(75, 192, 192)', tension: 0.1 }] },
+        options: { responsive: true, scales: { y: { beginAtZero: true } } }
+    });
+
+    try {
+        const resp = await fetch(`${API_BASE}/all-today?pot_id=${potId}`);
+        const data = await resp.json();
+        if (Array.isArray(data)) {
+            data.forEach(d => {
+                chart.data.labels.push(d.created);
+                chart.data.datasets[0].data.push(d.temperature);
+            });
+            chart.update();
+        }
+    } catch (e) {
+        console.error('Fehler beim Laden der Temperaturdaten', e);
+    }
+});

--- a/Plantify new/plantify/templates/plant.html
+++ b/Plantify new/plantify/templates/plant.html
@@ -42,6 +42,11 @@
         </div>
         <button id="save-facts-btn" class="pflege-edit" style="margin-top:10px;">Speichern</button>
     </div>
+
+    <div class="card full-width-card">
+        <h3>Temperatur Verlauf</h3>
+        <canvas id="chart-temp"></canvas>
+    </div>
 </div>
 
 <script>
@@ -80,4 +85,6 @@ document.addEventListener('DOMContentLoaded', function () {
   }
 });
 </script>
+<script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+<script src="{{ url_for('static', filename='temperature_chart.js') }}"></script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- add new temperature_chart.js to render temperature history
- display a chart on plant detail page

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685ab073e93c832fb4269cb0c593f2fc