### PR TITLE
Move temperature chart into room dashboard

### DIFF
--- a/Plantify new/plantify/templates/plant.html
+++ b/Plantify new/plantify/templates/plant.html
@@ -43,10 +43,6 @@
         <button id="save-facts-btn" class="pflege-edit" style="margin-top:10px;">Speichern</button>
     </div>
 
-    <div class="card full-width-card">
-        <h3>Temperatur Verlauf</h3>
-        <canvas id="chart-temp"></canvas>
-    </div>
 </div>
 
 <script>
@@ -85,6 +81,5 @@ document.addEventListener('DOMContentLoaded', function () {
   }
 });
 </script>
-<script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
-<script src="{{ url_for('static', filename='temperature_chart.js') }}"></script>
+
 {% endblock %}


### PR DESCRIPTION
## Summary
- remove temperature chart from plant detail page so that temperature data is shown only in the room dashboard

## Testing
- `python -m compileall -q 'Plantify new'/plantify`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685ab4ddca9c832f992104abeafe63ec