### PR TITLE
Add temperature chart to room dashboard

### DIFF
--- a/Plantify new/plantify/static/dashboard.js
+++ b/Plantify new/plantify/static/dashboard.js
@@ -14,7 +14,12 @@ function createChart(ctx, label) {
 }
 
 document.addEventListener('DOMContentLoaded', async () => {
-    const potId = new URLSearchParams(window.location.search).get('pot_id') || '1';
+    const params = new URLSearchParams(window.location.search);
+    let potId = params.get('pot_id');
+    if (!potId) {
+        const firstRow = document.querySelector('#care-guidelines tbody tr');
+        potId = firstRow ? firstRow.dataset.potId : '1';
+    }
     const charts = {
         sun: createChart(document.getElementById('chart-sun'), 'Sonnenstunden'),
         temp: createChart(document.getElementById('chart-temp'), 'Temperatur (°C)'),

--- a/Plantify new/plantify/templates/dashboard.html
+++ b/Plantify new/plantify/templates/dashboard.html
@@ -35,7 +35,7 @@
             <canvas id="chart-sun"></canvas>
         </div>
         <div class="chart-container">
-            <h3>Temperatur Verlauf</h3>
+            <h3><a href="{{ url_for('diagramm_temperatur') }}">Temperatur Verlauf</a></h3>
             <canvas id="chart-temp"></canvas>
         </div>
         <div class="chart-container">


### PR DESCRIPTION
## Summary
- show room temperature chart using a pot id from the first plant if no query parameter is provided
- link the temperature history page from the room dashboard

## Testing
- `pytest -q`
- `python -m py_compile $(git ls-files '*.py' -z | xargs -0)`

------
https://chatgpt.com/codex/tasks/task_e_685ab74a3ad8832f9360b8920e180a99