### PR TITLE
Show temperature chart directly

### DIFF
--- a/Plantify new/plantify/templates/dashboard.html
+++ b/Plantify new/plantify/templates/dashboard.html
@@ -35,7 +35,7 @@
             <canvas id="chart-sun"></canvas>
         </div>
         <div class="chart-container">
-            <h3><a href="{{ url_for('diagramm_temperatur') }}">Temperatur Verlauf</a></h3>
+            <h3>Temperatur Verlauf</h3>
             <canvas id="chart-temp"></canvas>
         </div>
         <div class="chart-container">


### PR DESCRIPTION
## Summary
- update dashboard page to display temperature curve heading without linking away

## Testing
- `python3 -m py_compile $(find 'Plantify new/plantify' -name '*.py' -exec python3 -m py_compile {} +)`

------
https://chatgpt.com/codex/tasks/task_e_685ab90b2a5c832fa4e06c10a6d05b62