### PR TITLE
Add temperature chart directly in dashboard

### DIFF
--- a/Plantify new/plantify/templates/dashboard.html
+++ b/Plantify new/plantify/templates/dashboard.html
@@ -36,7 +36,7 @@
         </div>
         <div class="chart-container">
             <h3>Temperatur Verlauf</h3>
-            <iframe src="{{ url_for('diagramm_temperatur') }}" class="temperature-iframe"></iframe>
+            <canvas id="chart-temp"></canvas>
         </div>
         <div class="chart-container">
             <h3>Bodenfeuchtigkeit Verlauf</h3>


### PR DESCRIPTION
## Summary
- add a canvas element for the temperature history chart in `dashboard.html`

## Testing
- `python -m py_compile "Plantify new"/plantify/app.py`
- `python -m py_compile "Plantify new"/plantify/*.py`
- `python -m py_compile "Plantify new"/plantify/smartplant_api/*.py`


------
https://chatgpt.com/codex/tasks/task_e_685bdbcd586c832fa32d68e854909211