### PR TITLE
Add fallback data for temperature chart

### DIFF
--- a/Plantify new/plantify/static/dashboard.js
+++ b/Plantify new/plantify/static/dashboard.js
@@ -5,12 +5,45 @@ const ENDPOINTS = {
     latest: `${API_BASE}/latest-value`
 };
 
+// Fallback-Daten wenn die API nicht erreichbar ist
+const DUMMY_MEASUREMENTS = [
+    { created: '2025-06-22 08:00:00', temperature: 21.3, air_humidity: 40.0, ground_humidity: 35.5, HoS: 6.0 },
+    { created: '2025-06-22 09:00:00', temperature: 21.5, air_humidity: 40.5, ground_humidity: 35.8, HoS: 6.0 },
+    { created: '2025-06-22 10:00:00', temperature: 22.8, air_humidity: 41.0, ground_humidity: 36.1, HoS: 6.0 },
+    { created: '2025-06-22 11:00:00', temperature: 23.2, air_humidity: 41.5, ground_humidity: 36.4, HoS: 6.0 },
+    { created: '2025-06-22 12:00:00', temperature: 24.1, air_humidity: 42.0, ground_humidity: 36.7, HoS: 6.0 },
+    { created: '2025-06-22 13:00:00', temperature: 24.7, air_humidity: 42.5, ground_humidity: 37.0, HoS: 6.0 },
+    { created: '2025-06-22 14:00:00', temperature: 25.0, air_humidity: 43.0, ground_humidity: 37.3, HoS: 6.0 },
+    { created: '2025-06-22 15:00:00', temperature: 24.3, air_humidity: 43.5, ground_humidity: 37.6, HoS: 6.0 },
+    { created: '2025-06-22 16:00:00', temperature: 23.7, air_humidity: 44.0, ground_humidity: 37.9, HoS: 6.0 },
+    { created: '2025-06-22 17:00:00', temperature: 22.9, air_humidity: 44.5, ground_humidity: 38.2, HoS: 6.0 },
+    { created: '2025-06-22 18:00:00', temperature: 22.1, air_humidity: 45.0, ground_humidity: 38.5, HoS: 6.0 },
+    { created: '2025-06-22 19:00:00', temperature: 21.5, air_humidity: 45.5, ground_humidity: 38.8, HoS: 6.0 }
+];
+
 function createChart(ctx, label) {
     return new Chart(ctx, {
         type: 'line',
         data: { labels: [], datasets: [{ label, data: [], borderColor: 'rgb(75, 192, 192)', tension: 0.1 }] },
         options: { responsive: true, scales: { y: { beginAtZero: true } } }
     });
+}
+
+function applyMeasurements(measurements, charts) {
+    measurements.forEach(d => {
+        const t = d.created;
+        if (charts.temp) {
+            charts.temp.data.labels.push(t);
+            charts.temp.data.datasets[0].data.push(d.temperature);
+        }
+        charts.soil.data.labels.push(t);
+        charts.air.data.labels.push(t);
+        charts.soil.data.datasets[0].data.push(d.ground_humidity);
+        charts.air.data.datasets[0].data.push(d.air_humidity);
+    });
+    if (charts.temp) charts.temp.update();
+    charts.soil.update();
+    charts.air.update();
 }
 
 document.addEventListener('DOMContentLoaded', async () => {
@@ -35,23 +68,11 @@ document.addEventListener('DOMContentLoaded', async () => {
         const todayResp = await fetch(`${ENDPOINTS.today}?pot_id=${potId}`);
         const todayData = await todayResp.json();
         if (Array.isArray(todayData)) {
-            todayData.forEach(d => {
-                const t = d.created;
-                if (charts.temp) {
-                    charts.temp.data.labels.push(t);
-                    charts.temp.data.datasets[0].data.push(d.temperature);
-                }
-                charts.soil.data.labels.push(t);
-                charts.air.data.labels.push(t);
-                charts.soil.data.datasets[0].data.push(d.ground_humidity);
-                charts.air.data.datasets[0].data.push(d.air_humidity);
-            });
-            if (charts.temp) charts.temp.update();
-            charts.soil.update();
-            charts.air.update();
+            applyMeasurements(todayData, charts);
         }
     } catch (e) {
         console.error('Fehler beim Laden der Tagesdaten', e);
+        applyMeasurements(DUMMY_MEASUREMENTS, charts);
     }
 
     try {
@@ -66,6 +87,11 @@ document.addEventListener('DOMContentLoaded', async () => {
         }
     } catch (e) {
         console.error('Fehler beim Laden der Sonnenstunden', e);
+        DUMMY_MEASUREMENTS.forEach(d => {
+            charts.sun.data.labels.push(d.created);
+            charts.sun.data.datasets[0].data.push(d.HoS);
+        });
+        charts.sun.update();
     }
 
     // Ist-Werte für Pflegehinweise laden
@@ -81,6 +107,10 @@ document.addEventListener('DOMContentLoaded', async () => {
             row.querySelector('.val-soil').textContent = data.ground_humidity.toFixed(1);
         } catch (e) {
             console.error('Fehler beim Laden der Ist-Werte', e);
+            const d = DUMMY_MEASUREMENTS[DUMMY_MEASUREMENTS.length - 1];
+            row.querySelector('.val-temp').textContent = d.temperature.toFixed(1);
+            row.querySelector('.val-air').textContent = d.air_humidity.toFixed(1);
+            row.querySelector('.val-soil').textContent = d.ground_humidity.toFixed(1);
         }
     }
 });


### PR DESCRIPTION
## Summary
- include fallback measurement data in `dashboard.js`
- ensure charts render with dummy values if API calls fail

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_685be3639530832f98a09d01cc009831