### PR TITLE
Add Plotly-based temperature chart

### DIFF
--- a/Plantify new/plantify/static/style.css
+++ b/Plantify new/plantify/static/style.css
@@ -261,6 +261,12 @@ canvas {
     max-width: 100%;
 }
 
+iframe.plotly-frame {
+    width: 100%;
+    height: 400px;
+    border: none;
+}
+
 /* Charts card layout */
 .charts-card {
     grid-column: 1 / span 2;

--- a/Plantify new/plantify/templates/dashboard.html
+++ b/Plantify new/plantify/templates/dashboard.html
@@ -38,6 +38,7 @@
             <h3>Temperatur Verlauf</h3>
             <!-- Chart für Temperatur Verlauf -->
             <canvas id="chart-temp"></canvas>
+            <iframe src="{{ url_for('static', filename='temperatur_verlauf.html') }}" class="plotly-frame"></iframe>
         </div>
         <div class="chart-container">
             <h3>Bodenfeuchtigkeit Verlauf</h3>


### PR DESCRIPTION
## Summary
- incorporate Plotly temperature chart from `smartplant-api`
- embed the chart via an iframe in the dashboard
- style the iframe so it fits the chart grid

## Testing
- `python -m py_compile app.py smartplant_api/*.py`

------
https://chatgpt.com/codex/tasks/task_e_685bee872e5c832faeb1108c65b52371