### PR TITLE
Fix spacing around chart headings

### DIFF
--- a/Plantify new/plantify/static/style.css
+++ b/Plantify new/plantify/static/style.css
@@ -281,6 +281,11 @@ iframe.plotly-frame {
     justify-content: space-between;
 }
 
+/* Remove gap between chart headings and the charts */
+.chart-container h3 {
+    margin-bottom: 0;
+}
+
 .facts-card {
     grid-column: 3;
     grid-row: 2;


### PR DESCRIPTION
## Summary
- adjust the `style.css` to reduce spacing under chart headings

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685bfd770cfc832f88a8a4cb7bee7530