### PR TITLE
Move dashboard charts to top

### DIFF
--- a/Plantify new/plantify/static/style.css
+++ b/Plantify new/plantify/static/style.css
@@ -278,7 +278,7 @@ iframe.plotly-frame {
 .chart-container {
     display: flex;
     flex-direction: column;
-    justify-content: space-between;
+    justify-content: flex-start;
 }
 
 /* Remove gap between chart headings and the charts */


### PR DESCRIPTION
## Summary
- tweak chart container layout so charts start at the top of each grid card

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_685c07e62ad8832f9d696a3c9b6692e4