### PR TITLE
Fix plant list missing on room pages

### DIFF
--- a/Plantify new/plantify/app.py
+++ b/Plantify new/plantify/app.py
@@ -110,8 +110,9 @@ def dashboard(slug):
     room = next((r for r in ROOMS if slugify(r['name']) == slug), None)
     if not room:
         return "Zimmer nicht gefunden", 404
-    plants = [p for p in PLANTS if p.get('room') == room['name']]
-    return render_template('dashboard.html', room=room['name'], room_slug=slug, plants=plants)
+    room_plants = [p for p in PLANTS if p.get('room') == room['name']]
+    return render_template('dashboard.html', room=room['name'], room_slug=slug,
+                           room_plants=room_plants)
 
 # Seite zum Umbenennen der Zimmer
 @app.route('/rooms')

--- a/Plantify new/plantify/templates/dashboard.html
+++ b/Plantify new/plantify/templates/dashboard.html
@@ -17,7 +17,7 @@
                 </tr>
             </thead>
             <tbody>
-            {% for plant in plants %}
+            {% for plant in room_plants %}
                 <tr data-pot-id="{{ plant.id }}">
                     <td>{{ plant.name }}</td>
                     <td><span class="val-temp">--</span> / {{ plant.target_temperature }}</td>
@@ -52,7 +52,7 @@
     <div class="card facts-card" id="facts-box">
         <h3>Pflanzen Fakten</h3>
         <ul>
-        {% for plant in plants %}
+        {% for plant in room_plants %}
             {% if plant.facts %}
             <li>{{ plant.name }}: {{ plant.facts }}</li>
             {% endif %}


### PR DESCRIPTION
## Summary
- ensure room pages only override local plant list
- update dashboard template to use `room_plants`

## Testing
- `python3 -m py_compile "Plantify new/plantify/app.py"`

------
https://chatgpt.com/codex/tasks/task_e_685d320fb0d0832fbe4eec4bc36471db